### PR TITLE
Wrap SavedExtension in try-catch

### DIFF
--- a/lib/sb2.js
+++ b/lib/sb2.js
@@ -166,7 +166,14 @@ const blocks = function (project) {
  */
 const extensions = function (project) {
     const result = {count: 0, id: []};
-    const ext = project.info.savedExtensions;
+
+    try {
+        const ext = project.info.savedExtensions; 
+    } catch (error) {
+        if (error instanceof TypeError) {
+          console.log("A TypeError occurred:", error.message);
+        }
+    }
 
     // Check to ensure project includes any extensions
     if (typeof ext === 'undefined') return result;


### PR DESCRIPTION
Some sb2 records don't contain expected Extension records (ie. env-crawler).

### Resolves

This attempts to prevent Crawler from aborting connections to the MySQL DB, and/or aborting without grace, causing the following error to be raised `TypeError: Cannot read properties of undefined (reading 'savedExtensions')` [here](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Felasticbeanstalk$252Fcrawler-env$252Fvar$252Flog$252Fweb.stdout.log/log-events/i-087b2d9ddd7fd40e8)

### Proposed Changes

Wraps a call in a try-catch block for situations where certain fields aren't present.

### Reason for Changes

Resolves aborted connections which are querying the DB, and (potentially) fixes Crawler(?)

### Test Coverage

![DO IT LIVE](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaW1uYmtkZzczZ2tsZGg2cTIxOWV4cmhlcW9nNHhuZmFwNHFsbHE4bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/q7UpJegIZjsk0/giphy.gif)

