### PR TITLE
Return more info on analyzed project file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,11 @@ module.exports = function (buffer, callback) {
     parser(buffer, false, (err, result) => {
         if (err) return callback(err);
 
-        // Extract only the project object from the parser results
+        // Extract the project object from the parser results
         const project = result[0];
+        // Check if the input buffer was a zip file
+        const zip = result[1];
+        project.isZip = typeof zip !== 'undefined' && zip !== null;
 
         // Push project object to the appropriate analysis handler
         switch (project.projectVersion) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ module.exports = function (buffer, callback) {
         const project = result[0];
         // Check if the input buffer was a zip file
         const zip = result[1];
-        project.isZip = typeof zip !== 'undefined' && zip !== null;
+        project.isBundle = typeof zip !== 'undefined' && zip !== null;
 
         // Push project object to the appropriate analysis handler
         switch (project.projectVersion) {

--- a/lib/sb2.js
+++ b/lib/sb2.js
@@ -246,7 +246,9 @@ module.exports = function (project, callback) {
         lists: extract(project, 'lists', 'listName'),
         comments: extract(project, 'scriptComments'),
         sounds: extract(project, 'sounds', 'soundName', 'md5'),
-        costumes: extract(project, 'costumes', 'costumeName', 'baseLayerMD5')
+        costumes: extract(project, 'costumes', 'costumeName', 'baseLayerMD5'),
+        projectVersion: 2,
+        isZip: project.isZip
     };
 
     meta.backdrops = backdrops(project);

--- a/lib/sb2.js
+++ b/lib/sb2.js
@@ -248,7 +248,7 @@ module.exports = function (project, callback) {
         sounds: extract(project, 'sounds', 'soundName', 'md5'),
         costumes: extract(project, 'costumes', 'costumeName', 'baseLayerMD5'),
         projectVersion: 2,
-        isZip: project.isZip
+        isBundle: project.isBundle
     };
 
     meta.backdrops = backdrops(project);

--- a/lib/sb3.js
+++ b/lib/sb3.js
@@ -188,7 +188,9 @@ module.exports = function (project, callback) {
         sprites: sprites(project.targets),
         blocks: blocks(project.targets),
         extensions: extensions(project.extensions),
-        meta: metadata(project.meta)
+        meta: metadata(project.meta),
+        projectVersion: 3,
+        isZip: project.isZip
     };
 
     callback(null, meta);

--- a/lib/sb3.js
+++ b/lib/sb3.js
@@ -190,7 +190,7 @@ module.exports = function (project, callback) {
         extensions: extensions(project.extensions),
         meta: metadata(project.meta),
         projectVersion: 3,
-        isZip: project.isZip
+        isBundle: project.isBundle
     };
 
     callback(null, meta);

--- a/test/unit/sb2.js
+++ b/test/unit/sb2.js
@@ -88,6 +88,12 @@ test('default (object)', t => {
         t.type(result.meta, 'object');
         t.same(result.meta, {});
 
+        t.type(result.projectVersion, 'number');
+        t.equal(result.projectVersion, 2);
+
+        t.type(result.isZip, 'boolean');
+        t.equal(result.isZip, false);
+
         t.end();
     });
 });
@@ -156,6 +162,12 @@ test('default (binary)', t => {
         t.type(result.extensions, 'object');
         t.equal(result.extensions.count, 0);
         t.same(result.extensions.id, []);
+
+        t.type(result.projectVersion, 'number');
+        t.equal(result.projectVersion, 2);
+
+        t.type(result.isZip, 'boolean');
+        t.equal(result.isZip, true);
 
         t.end();
     });
@@ -287,6 +299,12 @@ test('complex (binary)', t => {
         t.same(result.extensions.id, [
             'LEGO WeDo 2.0'
         ]);
+
+        t.type(result.projectVersion, 'number');
+        t.equal(result.projectVersion, 2);
+
+        t.type(result.isZip, 'boolean');
+        t.equal(result.isZip, true);
 
         t.end();
     });

--- a/test/unit/sb2.js
+++ b/test/unit/sb2.js
@@ -91,8 +91,8 @@ test('default (object)', t => {
         t.type(result.projectVersion, 'number');
         t.equal(result.projectVersion, 2);
 
-        t.type(result.isZip, 'boolean');
-        t.equal(result.isZip, false);
+        t.type(result.isBundle, 'boolean');
+        t.equal(result.isBundle, false);
 
         t.end();
     });
@@ -166,8 +166,8 @@ test('default (binary)', t => {
         t.type(result.projectVersion, 'number');
         t.equal(result.projectVersion, 2);
 
-        t.type(result.isZip, 'boolean');
-        t.equal(result.isZip, true);
+        t.type(result.isBundle, 'boolean');
+        t.equal(result.isBundle, true);
 
         t.end();
     });
@@ -303,8 +303,8 @@ test('complex (binary)', t => {
         t.type(result.projectVersion, 'number');
         t.equal(result.projectVersion, 2);
 
-        t.type(result.isZip, 'boolean');
-        t.equal(result.isZip, true);
+        t.type(result.isBundle, 'boolean');
+        t.equal(result.isBundle, true);
 
         t.end();
     });

--- a/test/unit/sb3.js
+++ b/test/unit/sb3.js
@@ -100,8 +100,8 @@ test('default (object)', t => {
         t.type(result.projectVersion, 'number');
         t.equal(result.projectVersion, 3);
 
-        t.type(result.isZip, 'boolean');
-        t.equal(result.isZip, false);
+        t.type(result.isBundle, 'boolean');
+        t.equal(result.isBundle, false);
 
         t.end();
     });
@@ -182,8 +182,8 @@ test('default (binary)', t => {
         t.type(result.projectVersion, 'number');
         t.equal(result.projectVersion, 3);
 
-        t.type(result.isZip, 'boolean');
-        t.equal(result.isZip, true);
+        t.type(result.isBundle, 'boolean');
+        t.equal(result.isBundle, true);
 
         t.end();
     });
@@ -319,8 +319,8 @@ test('complex (binary)', t => {
         t.type(result.projectVersion, 'number');
         t.equal(result.projectVersion, 3);
 
-        t.type(result.isZip, 'boolean');
-        t.equal(result.isZip, true);
+        t.type(result.isBundle, 'boolean');
+        t.equal(result.isBundle, true);
 
         t.end();
     });
@@ -415,8 +415,8 @@ test('regression test IBE-198, a bad list does not break library', t => {
         t.type(result.projectVersion, 'number');
         t.equal(result.projectVersion, 3);
 
-        t.type(result.isZip, 'boolean');
-        t.equal(result.isZip, false);
+        t.type(result.isBundle, 'boolean');
+        t.equal(result.isBundle, false);
 
         t.end();
     });

--- a/test/unit/sb3.js
+++ b/test/unit/sb3.js
@@ -96,6 +96,13 @@ test('default (object)', t => {
 
         t.type(result.meta, 'object');
         t.equal(result.meta.origin, 'test.scratch.mit.edu');
+
+        t.type(result.projectVersion, 'number');
+        t.equal(result.projectVersion, 3);
+
+        t.type(result.isZip, 'boolean');
+        t.equal(result.isZip, false);
+
         t.end();
     });
 });
@@ -171,6 +178,12 @@ test('default (binary)', t => {
 
         t.type(result.meta, 'object');
         t.same({}, result.meta);
+
+        t.type(result.projectVersion, 'number');
+        t.equal(result.projectVersion, 3);
+
+        t.type(result.isZip, 'boolean');
+        t.equal(result.isZip, true);
 
         t.end();
     });
@@ -303,6 +316,12 @@ test('complex (binary)', t => {
             'wedo2'
         ]);
 
+        t.type(result.projectVersion, 'number');
+        t.equal(result.projectVersion, 3);
+
+        t.type(result.isZip, 'boolean');
+        t.equal(result.isZip, true);
+
         t.end();
     });
 });
@@ -392,6 +411,13 @@ test('regression test IBE-198, a bad list does not break library', t => {
 
         t.type(result.meta, 'object');
         t.equal(result.meta.origin, 'test.scratch.mit.edu');
+
+        t.type(result.projectVersion, 'number');
+        t.equal(result.projectVersion, 3);
+
+        t.type(result.isZip, 'boolean');
+        t.equal(result.isZip, false);
+
         t.end();
     });
 });


### PR DESCRIPTION
### Resolves

- Resolves https://scratchfoundation.atlassian.net/browse/DPR-527

### Proposed Changes

Add `projectVersion` and `isZip` to analysis results.

### Reason for Changes

Currently the library doesn't return any info on:
- the version of the analyzed project file, and
- whether the analyzed buffer is a `project.json` file or an `sb2`/`sb3` bundle (ZIP file).

Return these two data points, so that an additional invocation of `scratch-parser` is not needed to determine them.

### Test Coverage

- Added unit tests.
