### PR TITLE
Fix error when checking for cloud variables

### DIFF
--- a/lib/sb3.js
+++ b/lib/sb3.js
@@ -134,7 +134,7 @@ const blocks = function (targets) {
             // Get opcode and check variable manipulation for the presence of
             // cloud variables
             if (opcode === 'data_setvariableto' || opcode === 'data_changevariableby') {
-                if (isArgCloudVar(block.fields.VARIABLE[1])) {
+                if (isArgCloudVar(block?.fields?.VARIABLE?.[1])) {
                     opcode += '_cloud';
                 }
             }

--- a/test/fixtures/sb3/missingVariableField.json
+++ b/test/fixtures/sb3/missingVariableField.json
@@ -1,0 +1,31 @@
+{
+    "targets": [
+        {
+            "isStage": true,
+            "name": "Stage",
+            "variables": {},
+            "blocks": {
+                "a": {
+                    "opcode": "data_setvariableto",
+                    "fields": {}
+                }
+            },
+            "costumes": [
+                {
+                    "assetId": "cd21514d0531fdffb22204e0ec5ed84a",
+                    "name": "backdrop1",
+                    "md5ext": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+                    "dataFormat": "svg",
+                    "rotationCenterX": 240,
+                    "rotationCenterY": 180
+                }
+            ],
+            "sounds": []
+        }
+    ],
+    "monitors": [],
+    "extensions": [],
+    "meta": {
+        "semver": "3.0.0"
+    }
+}

--- a/test/unit/sb3.js
+++ b/test/unit/sb3.js
@@ -25,6 +25,10 @@ const primitiveVariableAndListBlocks = fs.readFileSync(
     path.resolve(__dirname, '../fixtures/sb3/primitiveVariableAndListBlocks.json')
 );
 
+const missingVariableField = fs.readFileSync(
+    path.resolve(__dirname, '../fixtures/sb3/missingVariableField.json')
+);
+
 test('default (object)', t => {
     analysis(defaultObject, (err, result) => {
         t.ok(typeof err === 'undefined' || err === null);
@@ -469,6 +473,15 @@ test('correctly handling primitve reporter blocks: list and variable', t => {
             motion_changexby: 1,
             data_variable: 1
         });
+        t.end();
+    });
+});
+
+test('missing VARIABLE field in a block does not break the library', t => {
+    analysis(missingVariableField, (err, result) => {
+        t.ok(typeof err === 'undefined' || err === null);
+        t.type(result, 'object');
+
         t.end();
     });
 });


### PR DESCRIPTION
### Proposed Changes
Fix an unexpected error when checking for cloud variables:
```
if (isArgCloudVar(block.fields.VARIABLE[1])) {
^
TypeError: Cannot read properties of undefined (reading '1')
```

### Reason for Changes
- The ability to process project files where the `VARIABLE` field is missing.

### Test Coverage
- Unit test.
